### PR TITLE
ralink_inic: Do load_module on start() in init script

### DIFF
--- a/kernel/ralink_inic/files/etc/init.d/rt3883.init
+++ b/kernel/ralink_inic/files/etc/init.d/rt3883.init
@@ -77,5 +77,8 @@ boot() {
         load_module
 }
 
-start() { :; }
+start() {
+        load_module
+}
+
 stop() { :; }


### PR DESCRIPTION
That's the whole point of it, after all.